### PR TITLE
chore: add .claude/settings.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ next-env.d.ts
 
 # Claude Code config with credentials
 .claude/mcp_settings.json
+.claude/settings.json
 
 # Context assets (private info)
 docs/context-assets/


### PR DESCRIPTION
## Summary
Adds `.claude/settings.json` to .gitignore to prevent accidental commits of Claude Code settings that may contain credentials.

## Changes
- Added `.claude/settings.json` to .gitignore

## Why
The settings.json file is created locally to enable autonomous Claude Code operation with auto-approve patterns. However, it should never be committed because it may contain references to API credentials (like Jira tokens) in the auto-approve patterns.

## Testing
- [x] Verified .gitignore syntax
- [x] Confirmed settings.json is excluded from git status
- [x] Single atomic commit following conventional commits format

## Related Issues
Follows GitHub skills workflow patterns defined in `.claude/skills/github-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)